### PR TITLE
module/umount: fixup 12925a3

### DIFF
--- a/module/template/umount
+++ b/module/template/umount
@@ -1,3 +1,3 @@
 source { "KSU", "APatch", "magisk", "worker" } fs { "tmpfs" "overlay" }
-point {"/system/etc/hosts"}
+point { "/system/etc/hosts" }
 


### PR DESCRIPTION
apparently, missing a space doesnt get parsed. my bad.

Fixes:  `module/umount: umount hostsfile by default`